### PR TITLE
Finished add_date_to_folders feature

### DIFF
--- a/philharmonic/cloud/model.py
+++ b/philharmonic/cloud/model.py
@@ -17,6 +17,12 @@ from philharmonic.utils import deprecated, CommonEqualityMixin
 from . import visualiser
 
 def format_spec(spec):
+    """Return a string containing the resource 
+    key-value pairs in spec (valid for PM and VM)
+
+    Sample output: 
+    {RAM:28 #CPUs:3}
+    """
     s = "{"
     separator = " "
     for key, value in spec.iteritems():

--- a/philharmonic/cloud/visualiser.py
+++ b/philharmonic/cloud/visualiser.py
@@ -40,7 +40,7 @@ def show_unallocated_vms(cloud, state):
 def show_usage(cloud, state):
     locations = get_locations(cloud)
     for location in locations:
-        info("\n{}\n---------------".format(location))
+        info("\n{}\n".format(location) + len(location) * '-')
         servers = servers_at_location(cloud, location)
         for server in servers:
             server_str = server.full_info(location=False)

--- a/philharmonic/scheduler/__init__.py
+++ b/philharmonic/scheduler/__init__.py
@@ -6,3 +6,4 @@ from .bcf_scheduler import BCFScheduler
 from .bcffs_scheduler import BCFFSScheduler
 from .bfd_scheduler import BFDScheduler
 from .ga.gascheduler import GAScheduler
+from .simple.simple_scheduler import SimpleScheduler

--- a/philharmonic/scheduler/evaluator.py
+++ b/philharmonic/scheduler/evaluator.py
@@ -669,16 +669,20 @@ def calculate_service_profit(cloud, environment, schedule,
     df_beta = pd.DataFrame(
         [{vm : vm.beta for vm in considered_vms}], [start]
     )
-    df_beta = df_beta.reindex(freq.index, method='pad')
+    if conf.power_freq_model:
+        df_beta = df_beta.reindex(freq.index, method='pad')
     ram_size_base = 1 # 1000 # 1024
     ram_index = 'RAM'
     df_rel_ram = pd.DataFrame([{vm : vm.res[ram_index] / ram_size_base \
                                 for vm in considered_vms}], [start])
-    df_rel_ram = df_rel_ram.reindex(freq.index, method='pad')
+    if conf.power_freq_model:
+        df_rel_ram = df_rel_ram.reindex(freq.index, method='pad')
     # df_price = ph.vm_price_progressive(
     #     freq, df_beta, C_base=conf.C_base, C_dif=conf.C_dif_cpu,
     #     f_base=conf.f_base, f_max=conf.f_max
     # )
+    if not conf.power_freq_model:
+        freq = 0
     df_price = ph.vm_price_cpu_ram(
         df_rel_ram, freq, df_beta, C_base=conf.C_base, C_dif_cpu=conf.C_dif_cpu,
         C_dif_ram=conf.C_dif_ram, f_base=conf.f_base, f_max=conf.f_max

--- a/philharmonic/scheduler/fbf_scheduler.py
+++ b/philharmonic/scheduler/fbf_scheduler.py
@@ -48,8 +48,10 @@ class FBFScheduler(IScheduler):
         #    import ipdb; ipdb.set_trace()
         for request in requests:
             if request.what == 'boot':
+
                 server = self.find_host(request.vm)
                 if server is None:
+                    import ipdb; ipdb.set_trace()
                     raise Exception("not enough free resources")
                 action = Migration(request.vm, server)
                 self.cloud.apply(action)

--- a/philharmonic/scheduler/ga/gascheduler.py
+++ b/philharmonic/scheduler/ga/gascheduler.py
@@ -307,12 +307,16 @@ class GAScheduler(IScheduler):
             # - maybe add all afterwards
             # TODO: precise indexing, not dict
             # TODO: never directly modify alloc - use place and remove
-            if isinstance(schedule.actions[t], pd.Series):
-                for action in schedule.actions[t].values:
+            try: 
+                if isinstance(schedule.actions[t], pd.Series):
+                    for action in schedule.actions[t].values:
+                        self.cloud.apply(action)
+                else:
+                    action = schedule.actions[t]
                     self.cloud.apply(action)
-            else:
-                action = schedule.actions[t]
-                self.cloud.apply(action)
+            except KeyError:
+                import ipdb; ipdb.set_trace()
+
             state = self.cloud.get_current()
             if not state.all_within_capacity():
                 for server in self.cloud.servers:
@@ -430,7 +434,7 @@ class GAScheduler(IScheduler):
         # debug unallocated VMs
         if best.constr > 0:
             # something is amiss if the best schedule broke constraints
-            #import ipdb; ipdb.set_trace()
+            import ipdb; ipdb.set_trace()
             pass
         return best
 

--- a/philharmonic/scheduler/simple/simple_scheduler.py
+++ b/philharmonic/scheduler/simple/simple_scheduler.py
@@ -1,0 +1,66 @@
+from philharmonic.scheduler.ischeduler import IScheduler
+from philharmonic import Schedule, Migration
+from philharmonic.logger import info, debug, error
+
+class SimpleScheduler(IScheduler):
+    """Simple scheduler."""
+
+    def __init__(self, cloud=None, driver=None):
+        IScheduler.__init__(self, cloud, driver)
+
+    def _fits(self, vm, server):
+        """Returns the utilisation of adding vm to server
+        or -1 in case some resource's capacity is exceeded.
+
+        """
+        #TODO: this method should probably be a part of Cloud
+        current = self.cloud.get_current()
+        total_utilisation = 0.
+        utilisations = {}
+        for i in server.resource_types:
+            used = 0.
+            for existing_vm in current.alloc[server]:
+                used += existing_vm.res[i]
+            # add our own VM's resource demand
+            used += vm.res[i]
+            utilisations[i] = used/server.cap[i]
+            if used > server.cap[i]: # capacity exceeded for this resource
+                return -1
+        uniform_weight = 1./len(server.resource_types)
+        weights = {res : uniform_weight for res in server.resource_types}
+        for resource_type, utilisation in utilisations.iteritems():
+            total_utilisation += weights[resource_type] * utilisation
+        return total_utilisation
+
+    def find_host(self, vm):
+        for server in self.cloud.servers:
+            utilisation = self._fits(vm, server)
+            #TODO: compare utilisations of different potential hosts
+            if utilisation != -1:
+                return server
+        return None
+
+    def reevaluate(self):
+        self.schedule = Schedule()
+        t = self.environment.get_time()
+        # get new requests
+        requests = self.environment.get_requests()
+        # if len(requests) > 0:
+        #    import ipdb; ipdb.set_trace()
+        for request in requests:
+            if request.what == 'boot':
+
+                server = self.find_host(request.vm)
+                if server is None:
+                    error('not enough free resources for VM {}'.format(request.vm))
+                else:
+                    action = Migration(request.vm, server)
+                    self.cloud.apply(action)
+                    self.schedule.add(action, t)
+        # for each boot request:
+        # find the best server
+        #  - find server that can host this VM
+        #  - make sure the server's resources are now reserved
+        # add new migration to the schedule
+        self.cloud.reset_to_real()
+        return self.schedule

--- a/philharmonic/settings/base.py
+++ b/philharmonic/settings/base.py
@@ -170,7 +170,7 @@ inputgen_settings = {
     #'server_num': 50,
     #'server_num': 100,
     #'server_num': 200,
-    'server_num': 10, # 1200
+    'server_num': 1200,
     #'server_num': 2000,
     #'min_server_cpu': 8,
     'min_server_cpu': 1, # 16,
@@ -187,7 +187,7 @@ inputgen_settings = {
     # VM requests
     # method of generating requests: normal_vmreqs, auto_vmreqs
     'VM_request_generation_method': 'auto_vmreqs',
-    'VM_num': 20, # 2000
+    'VM_num': 2000,
     #'VM_num': 5, # only important with normal_vmreqs, not auto_vmreqs
     #'VM_num': 2000,
     # e.g. CPUs

--- a/philharmonic/settings/base.py
+++ b/philharmonic/settings/base.py
@@ -170,7 +170,7 @@ inputgen_settings = {
     #'server_num': 50,
     #'server_num': 100,
     #'server_num': 200,
-    'server_num': 1200,
+    'server_num': 10, # 1200
     #'server_num': 2000,
     #'min_server_cpu': 8,
     'min_server_cpu': 1, # 16,
@@ -187,7 +187,7 @@ inputgen_settings = {
     # VM requests
     # method of generating requests: normal_vmreqs, auto_vmreqs
     'VM_request_generation_method': 'auto_vmreqs',
-    'VM_num': 2000,
+    'VM_num': 20, # 2000
     #'VM_num': 5, # only important with normal_vmreqs, not auto_vmreqs
     #'VM_num': 2000,
     # e.g. CPUs

--- a/philharmonic/settings/base.py
+++ b/philharmonic/settings/base.py
@@ -32,6 +32,10 @@ prompt_ipdb = True
 common_output_folder = "io/"
 base_output_folder = os.path.join(common_output_folder, "results/test/")
 output_folder = base_output_folder
+cloud_input_folder = "../"
+add_date_to_folders = False
+if add_date_to_folders:
+    cloud_input_folder = "./"
 
 
 USAGE_LOC = "io/usage/" # path from the philharmonic root
@@ -68,6 +72,9 @@ start = pd.Timestamp('2010-06-03 00:00')
 # - one week
 times = pd.date_range(start, periods=24 * 7, freq='H')
 end = times[-1]
+
+from time import localtime
+current_time = localtime() #pd.datetime.now()
 
 # plotting results
 plotserver = True

--- a/philharmonic/settings/extended.py
+++ b/philharmonic/settings/extended.py
@@ -1,8 +1,8 @@
 from .base import *
 
-output_folder = os.path.join(base_output_folder, "simple/")
+output_folder = os.path.join(base_output_folder, "extended/")
 
-prompt_configuration = False
+prompt_configuration = True
 prompt_show_cloud = False
 
 factory['cloud'] = "small_infrastructure"

--- a/philharmonic/settings/ga_hybrid_simple.py
+++ b/philharmonic/settings/ga_hybrid_simple.py
@@ -1,9 +1,6 @@
-from .base import *
+from .ga_hybrid import *
 
-output_folder = os.path.join(base_output_folder, "simple/")
-
-prompt_configuration = False
-prompt_show_cloud = False
+output_folder = os.path.join(base_output_folder, "ga_hybrid_simple/")
 
 factory['cloud'] = "small_infrastructure"
 factory['requests'] = "simple_vmreqs"

--- a/philharmonic/settings/ga_hybrid_small_simple.py
+++ b/philharmonic/settings/ga_hybrid_small_simple.py
@@ -1,0 +1,6 @@
+from .ga_hybrid_simple import *
+
+output_folder = os.path.join(base_output_folder, "ga_hybrid_small_simple/")
+
+
+gaconf["max_generations"] = 60

--- a/philharmonic/settings/simple.py
+++ b/philharmonic/settings/simple.py
@@ -2,17 +2,7 @@ from .base import *
 
 output_folder = os.path.join(base_output_folder, "simple/")
 
-prompt_configuration = False
-prompt_show_cloud = False
-
-factory['cloud'] = "small_infrastructure"
-factory['requests'] = "simple_vmreqs"
-    #  simple_el, medium_el, usa_el, world_el, dynamic_usa_el
-    #  simple_temperature, medium_temperature, usa_temperature,
-    #  world_temperature, dynamic_usa_temp
-factory['el_prices'] = "simple_el"
-factory['temperature'] = "simple_temperature"
-
+# prompt_configuration = True
 
 inputgen_settings['server_num'] = 10
 inputgen_settings['VM_num'] = 20

--- a/philharmonic/settings/simple.py
+++ b/philharmonic/settings/simple.py
@@ -8,3 +8,7 @@ inputgen_settings['server_num'] = 10
 inputgen_settings['VM_num'] = 20
 
 add_date_to_folders = True
+
+prompt_configuration = True
+
+power_freq_model = False

--- a/philharmonic/settings/simple.py
+++ b/philharmonic/settings/simple.py
@@ -14,3 +14,6 @@ prompt_configuration = True
 power_freq_model = False
 
 factory['temperature'] = None
+
+factory['scheduler'] = 'SimpleScheduler'
+factory['environment'] = 'SimpleSimulatedEnvironment'

--- a/philharmonic/settings/simple.py
+++ b/philharmonic/settings/simple.py
@@ -1,0 +1,18 @@
+from .base import *
+
+output_folder = os.path.join(base_output_folder, "simple/")
+
+prompt_configuration = False
+prompt_show_cloud = False
+
+factory['cloud'] = "small_infrastructure"
+factory['requests'] = "simple_vmreqs"
+    #  simple_el, medium_el, usa_el, world_el, dynamic_usa_el
+    #  simple_temperature, medium_temperature, usa_temperature,
+    #  world_temperature, dynamic_usa_temp
+factory['el_prices'] = "simple_el"
+factory['temperature'] = "simple_temperature"
+
+
+inputgen_settings['server_num'] = 1
+inputgen_settings['VM_num'] = 2

--- a/philharmonic/settings/simple.py
+++ b/philharmonic/settings/simple.py
@@ -12,3 +12,5 @@ add_date_to_folders = True
 prompt_configuration = True
 
 power_freq_model = False
+
+factory['temperature'] = None

--- a/philharmonic/settings/simple.py
+++ b/philharmonic/settings/simple.py
@@ -8,5 +8,3 @@ inputgen_settings['server_num'] = 10
 inputgen_settings['VM_num'] = 20
 
 add_date_to_folders = True
-
-# info('Current time: {}'.format(conf.current_time))

--- a/philharmonic/settings/simple.py
+++ b/philharmonic/settings/simple.py
@@ -1,8 +1,12 @@
 from .base import *
+from philharmonic.logger import *
+from philharmonic import conf
 
 output_folder = os.path.join(base_output_folder, "simple/")
 
-# prompt_configuration = True
-
 inputgen_settings['server_num'] = 10
 inputgen_settings['VM_num'] = 20
+
+add_date_to_folders = True
+
+# info('Current time: {}'.format(conf.current_time))

--- a/philharmonic/simulator/environment.py
+++ b/philharmonic/simulator/environment.py
@@ -95,7 +95,7 @@ class SimulatedEnvironment(Environment):
 
     def model_forecast_errors(self, SD_el, SD_temp):
         self.forecast_el = self._generate_forecast(self.el_prices, SD_el)
-        if not self.temperature is None:
+        if self.temperature is not None:
             self.forecast_temp = self._generate_forecast(self.temperature, SD_temp)
 
 class PPSimulatedEnvironment(SimulatedEnvironment):
@@ -154,3 +154,8 @@ class FBFSimpleSimulatedEnvironment(SimulatedEnvironment):
 
 class GASimpleSimulatedEnvironment(FBFSimpleSimulatedEnvironment):
     pass
+
+class SimpleSimulatedEnvironment(FBFSimpleSimulatedEnvironment):
+    pass
+
+    

--- a/philharmonic/simulator/environment.py
+++ b/philharmonic/simulator/environment.py
@@ -82,10 +82,12 @@ class SimulatedEnvironment(Environment):
             el_prices = self.forecast_el[self.t:self.forecast_end]
         else:
             el_prices = self.el_prices[self.t:self.forecast_end]
-        if forecast and hasattr(self, 'forecast_temp'):
-            temperature = self.forecast_temp[self.t:self.forecast_end]
-        else:
-            temperature = self.temperature[self.t:self.forecast_end]
+
+        if not temperature is None:
+            if forecast and hasattr(self, 'forecast_temp'):
+                temperature = self.forecast_temp[self.t:self.forecast_end]
+            else:
+                temperature = self.temperature[self.t:self.forecast_end]
         return el_prices, temperature
 
     def _generate_forecast(self, data, SD):
@@ -93,7 +95,8 @@ class SimulatedEnvironment(Environment):
 
     def model_forecast_errors(self, SD_el, SD_temp):
         self.forecast_el = self._generate_forecast(self.el_prices, SD_el)
-        self.forecast_temp = self._generate_forecast(self.temperature, SD_temp)
+        if not self.temperature is None:
+            self.forecast_temp = self._generate_forecast(self.temperature, SD_temp)
 
 class PPSimulatedEnvironment(SimulatedEnvironment):
     """Peak pauser simulation scenario with one location, el price"""
@@ -119,7 +122,8 @@ class FBFSimpleSimulatedEnvironment(SimulatedEnvironment):
             self._t = 0
             self._period = 1
             self.el_prices = []
-            self.temperature = []
+            if not temperature is None:
+                self.temperature = []
         self._forecast_periods = forecast_periods
 
     # TODO: better to make the environment immutable

--- a/philharmonic/simulator/inputgen.py
+++ b/philharmonic/simulator/inputgen.py
@@ -142,6 +142,7 @@ beta_option = 1
 max_cloud_usage = 0.8
 
 def within_cloud_capacity(cloud_capacity, requested_capacity, max_cloud_usage):
+    """Iterate through each resource and its (total) capacity"""
     for res, capacity in cloud_capacity.items():
         if requested_capacity[res] > capacity * max_cloud_usage:
             return False

--- a/philharmonic/simulator/inputgen.py
+++ b/philharmonic/simulator/inputgen.py
@@ -113,7 +113,7 @@ def normal_infrastructure(locations=['A', 'B'],
 
     servers = []
     for cpu_size, ram_size in zip(cpu_sizes, ram_sizes):
-        location = random.sample(locations, 1)[0]
+        location = random.sample(locations, 1)[0] # return a random sample from all locations
         server = Server(ram_size, cpu_size, location=location)
         servers.append(server)
     return Cloud(servers=servers)

--- a/philharmonic/simulator/inputgen.py
+++ b/philharmonic/simulator/inputgen.py
@@ -100,7 +100,7 @@ max_server_ram = 8
 def normal_infrastructure(locations=['A', 'B'],
                           round_to_hour=True):
     """Generate the cloud's servers with random specs and
-    uniformly distributed over all the locations
+    uniformly or normally distributed over all the locations
 
     """
     # array of server sizes

--- a/philharmonic/simulator/results.py
+++ b/philharmonic/simulator/results.py
@@ -54,7 +54,10 @@ def generate_series_results(cloud, env, schedule, nplots):
     # cooling overhead
     #-----------------
     #temperature = inputgen.simple_temperature()
-    power_total = evaluator.calculate_cloud_cooling(power, env.temperature)
+    if env.temperature is not None:
+        power_total = evaluator.calculate_cloud_cooling(power, env.temperature)
+    else:
+        power_total = power
     ax = plt.subplot(nplots, 1, 4)
     ax.set_title('Total power (W)')
     power_total.plot(ax=ax)
@@ -102,9 +105,11 @@ def serialise_results(cloud, env, schedule):
     ax = plt.subplot(nplots, 1, 1)
     ax.set_title('Electricity prices ($/kWh)')
     env.el_prices.plot(ax=ax)
-    ax = plt.subplot(nplots, 1, 2)
-    ax.set_title('Temperature (C)')
-    env.temperature.plot(ax=ax)
+
+    if env.temperature is not None:
+        ax = plt.subplot(nplots, 1, 2)
+        ax.set_title('Temperature (C)')
+        env.temperature.plot(ax=ax)
 
     # dynamic results
     #----------------

--- a/philharmonic/simulator/results.py
+++ b/philharmonic/simulator/results.py
@@ -14,11 +14,11 @@ from philharmonic import conf
 import philharmonic as ph
 from philharmonic.logger import *
 from philharmonic.scheduler import evaluator
-from philharmonic.utils import loc, common_loc
+from philharmonic.utils import loc, loc_date, common_loc
 from philharmonic import Schedule
 
 def pickle_results(schedule):
-    schedule.actions.to_pickle(loc('schedule.pkl'))
+    schedule.actions.to_pickle(loc_date('schedule.pkl'))
 
 def generate_series_results(cloud, env, schedule, nplots):
     info('\nDynamic results\n---------------')
@@ -41,7 +41,7 @@ def generate_series_results(cloud, env, schedule, nplots):
     # TODO: add frequency to this power calculation
     power = evaluator.generate_cloud_power(util)
     if conf.save_power:
-        power.to_pickle(loc('power.pkl'))
+        power.to_pickle(loc_date('power.pkl'))
     ax = plt.subplot(nplots, 1, 3)
     ax.set_title('Computational power (W)')
     power.plot(ax=ax)
@@ -59,7 +59,7 @@ def generate_series_results(cloud, env, schedule, nplots):
     ax.set_title('Total power (W)')
     power_total.plot(ax=ax)
     if conf.save_power:
-        power_total.to_pickle(loc('power_total.pkl'))
+        power_total.to_pickle(loc_date('power_total.pkl'))
     energy_total = ph.joul2kwh(ph.calculate_energy(power_total))
     # info('\nEnergy with cooling (kWh)')
     # info(energy_total)
@@ -202,7 +202,7 @@ def serialise_results(cloud, env, schedule):
     # Towards Profitable Virtual Machine Placement in the Data Center Shi
     # and Hong 2011 - total profit, revenue and operational cost
     aggregated_results = pd.Series(aggregated, aggr_names)
-    aggregated_results.to_pickle(loc('results.pkl'))
+    aggregated_results.to_pickle(loc_date('results.pkl'))
     #aggregated_results.plot(kind='bar')
     info('\n')
     info(aggregated_results)
@@ -210,7 +210,7 @@ def serialise_results(cloud, env, schedule):
     if conf.liveplot:
         plt.show()
     elif conf.liveplot:
-        plt.savefig(loc('results-graph.pdf'))
+        plt.savefig(loc_date('results-graph.pdf'))
 
     info('\nDone. Results saved to: {}'.format(conf.output_folder))
 

--- a/philharmonic/simulator/results.py
+++ b/philharmonic/simulator/results.py
@@ -14,11 +14,11 @@ from philharmonic import conf
 import philharmonic as ph
 from philharmonic.logger import *
 from philharmonic.scheduler import evaluator
-from philharmonic.utils import loc, loc_date, common_loc
+from philharmonic.utils import loc
 from philharmonic import Schedule
 
 def pickle_results(schedule):
-    schedule.actions.to_pickle(loc_date('schedule.pkl'))
+    schedule.actions.to_pickle(loc('schedule.pkl'))
 
 def generate_series_results(cloud, env, schedule, nplots):
     info('\nDynamic results\n---------------')
@@ -41,7 +41,7 @@ def generate_series_results(cloud, env, schedule, nplots):
     # TODO: add frequency to this power calculation
     power = evaluator.generate_cloud_power(util)
     if conf.save_power:
-        power.to_pickle(loc_date('power.pkl'))
+        power.to_pickle(loc('power.pkl'))
     ax = plt.subplot(nplots, 1, 3)
     ax.set_title('Computational power (W)')
     power.plot(ax=ax)
@@ -59,7 +59,7 @@ def generate_series_results(cloud, env, schedule, nplots):
     ax.set_title('Total power (W)')
     power_total.plot(ax=ax)
     if conf.save_power:
-        power_total.to_pickle(loc_date('power_total.pkl'))
+        power_total.to_pickle(loc('power_total.pkl'))
     energy_total = ph.joul2kwh(ph.calculate_energy(power_total))
     # info('\nEnergy with cooling (kWh)')
     # info(energy_total)
@@ -202,7 +202,7 @@ def serialise_results(cloud, env, schedule):
     # Towards Profitable Virtual Machine Placement in the Data Center Shi
     # and Hong 2011 - total profit, revenue and operational cost
     aggregated_results = pd.Series(aggregated, aggr_names)
-    aggregated_results.to_pickle(loc_date('results.pkl'))
+    aggregated_results.to_pickle(loc('results.pkl'))
     #aggregated_results.plot(kind='bar')
     info('\n')
     info(aggregated_results)
@@ -210,7 +210,9 @@ def serialise_results(cloud, env, schedule):
     if conf.liveplot:
         plt.show()
     elif conf.liveplot:
-        plt.savefig(loc_date('results-graph.pdf'))
+        plt.savefig(loc('results-graph.pdf'))
+
+    info('Current time: {}'.format(conf.current_time))
 
     info('\nDone. Results saved to: {}'.format(conf.output_folder))
 

--- a/philharmonic/simulator/results.py
+++ b/philharmonic/simulator/results.py
@@ -212,8 +212,6 @@ def serialise_results(cloud, env, schedule):
     elif conf.liveplot:
         plt.savefig(loc('results-graph.pdf'))
 
-    info('Current time: {}'.format(conf.current_time))
-
     info('\nDone. Results saved to: {}'.format(conf.output_folder))
 
     return aggregated_results

--- a/philharmonic/simulator/simulator.py
+++ b/philharmonic/simulator/simulator.py
@@ -274,7 +274,7 @@ def log_config_info(simulator):
 
     info('\nServers ({} -> will copy to: {})\n-------\n{}\n'.format(
         common_loc('workload/servers.pkl'),
-        os.path.relpath(loc(conf.cloud_input_folder + 'servers.pkl')),
+        os.path.relpath(loc(conf.cloud_input_folder + 'servers.pkl', input=True)),
         simulator.cloud.servers
         #pprint.pformat(simulator.cloud.servers)
         #simulator.cloud.show_usage()
@@ -284,7 +284,7 @@ def log_config_info(simulator):
     ))
     info('\nRequests ({} -> will copy to: {})\n--------\n{}\n'.format(
         common_loc('workload/requests.pkl'),
-        os.path.relpath(loc(conf.cloud_input_folder + 'requests.pkl')),
+        os.path.relpath(loc(conf.cloud_input_folder + 'requests.pkl', input=True)),
         simulator.requests)
     )
     if conf.prompt_configuration:
@@ -292,9 +292,9 @@ def log_config_info(simulator):
 
 def archive_inputs(simulator):
     """copy input files together with the results (for archive reasons)"""
-    with open(loc(conf.cloud_input_folder + 'servers.pkl'), 'w') as pkl_srv:
+    with open(loc(conf.cloud_input_folder + 'servers.pkl', input=True), 'w') as pkl_srv:
         pickle.dump(simulator.cloud, pkl_srv)
-    simulator.requests.to_pickle(loc(conf.cloud_input_folder + 'requests.pkl'))
+    simulator.requests.to_pickle(loc(conf.cloud_input_folder + 'requests.pkl', input=True))
 
 def before_start(simulator):
     log_config_info(simulator)

--- a/philharmonic/simulator/simulator.py
+++ b/philharmonic/simulator/simulator.py
@@ -272,16 +272,17 @@ def log_config_info(simulator):
             pprint.pformat(conf.factory['scheduler_conf'])
         ))
 
-    info('\nServers ({} -> will copy to: {})\n-------\n{}\n'.format(
+    info('\nServers ({} -> will copy to: {})\n-------\n{}'.format(
         common_loc('workload/servers.pkl'),
         os.path.relpath(loc(conf.cloud_input_folder + 'servers.pkl', input=True)),
         simulator.cloud.servers
         #pprint.pformat(simulator.cloud.servers)
         #simulator.cloud.show_usage()
     ))
-    info('- freq. scale from {} to {} by {}.'.format(
-        conf.freq_scale_min, conf.freq_scale_max, conf.freq_scale_delta
-    ))
+    if conf.power_freq_model is not False:
+        info('\n- freq. scale from {} to {} by {}.'.format(
+            conf.freq_scale_min, conf.freq_scale_max, conf.freq_scale_delta
+        ))
     info('\nRequests ({} -> will copy to: {})\n--------\n{}\n'.format(
         common_loc('workload/requests.pkl'),
         os.path.relpath(loc(conf.cloud_input_folder + 'requests.pkl', input=True)),

--- a/philharmonic/simulator/simulator.py
+++ b/philharmonic/simulator/simulator.py
@@ -274,7 +274,7 @@ def log_config_info(simulator):
 
     info('\nServers ({} -> will copy to: {})\n-------\n{}\n'.format(
         common_loc('workload/servers.pkl'),
-        os.path.relpath(loc('../servers.pkl')),
+        os.path.relpath(loc(conf.cloud_input_folder + 'servers.pkl')),
         simulator.cloud.servers
         #pprint.pformat(simulator.cloud.servers)
         #simulator.cloud.show_usage()
@@ -284,7 +284,7 @@ def log_config_info(simulator):
     ))
     info('\nRequests ({} -> will copy to: {})\n--------\n{}\n'.format(
         common_loc('workload/requests.pkl'),
-        os.path.relpath(loc('../requests.pkl')),
+        os.path.relpath(loc(conf.cloud_input_folder + 'requests.pkl')),
         simulator.requests)
     )
     if conf.prompt_configuration:
@@ -292,9 +292,9 @@ def log_config_info(simulator):
 
 def archive_inputs(simulator):
     """copy input files together with the results (for archive reasons)"""
-    with open(loc('../servers.pkl'), 'w') as pkl_srv:
+    with open(loc(conf.cloud_input_folder + 'servers.pkl'), 'w') as pkl_srv:
         pickle.dump(simulator.cloud, pkl_srv)
-    simulator.requests.to_pickle(loc('../requests.pkl'))
+    simulator.requests.to_pickle(loc(conf.cloud_input_folder + 'requests.pkl'))
 
 def before_start(simulator):
     log_config_info(simulator)

--- a/philharmonic/utils.py
+++ b/philharmonic/utils.py
@@ -22,7 +22,21 @@ def mkdir_p(path):
             pass
         else: raise
 
+# def loc(filepath):
+#     from philharmonic import conf
+#     if conf.add_date_to_folders:
+#         return loc_date(filepath)
+#     else:
+#         return loc_normal(filepath)
+
 def loc(filepath):
+    from philharmonic import conf
+    if conf.add_date_to_folders:
+        return loc_date(filepath)
+    else:
+        return loc_normal(filepath)
+
+def loc_normal(filepath):
     from philharmonic import conf
     new_path = os.path.join(conf.output_folder, os.path.dirname(filepath))
     mkdir_p(new_path)
@@ -31,8 +45,10 @@ def loc(filepath):
 def loc_date(filepath):
     from philharmonic import conf
     from time import strftime
-    date = strftime("%Y-%m-%d")
-    time = strftime("%H%M%S")
+    from time import mktime
+    date = strftime("%Y-%m-%d", conf.current_time)
+    time = strftime("%H%M%S", conf.current_time)
+    filepath = os.path.basename(filepath)
     filepath = time + "_" + filepath # save the time as part of the name of the output file
     filepath = date + "/" + filepath # put the file inside a folder of the current date
     new_path = os.path.join(conf.output_folder, os.path.dirname(filepath))

--- a/philharmonic/utils.py
+++ b/philharmonic/utils.py
@@ -28,6 +28,17 @@ def loc(filepath):
     mkdir_p(new_path)
     return os.path.join(conf.output_folder, filepath)
 
+def loc_date(filepath):
+    from philharmonic import conf
+    from time import strftime
+    date = strftime("%Y-%m-%d")
+    time = strftime("%H%M%S")
+    filepath = time + "_" + filepath # save the time as part of the name of the output file
+    filepath = date + "/" + filepath # put the file inside a folder of the current date
+    new_path = os.path.join(conf.output_folder, os.path.dirname(filepath))
+    mkdir_p(new_path)
+    return os.path.join(conf.output_folder, filepath)
+
 def common_loc(filepath):
     from philharmonic import conf
     new_path = os.path.join(conf.common_output_folder,

--- a/philharmonic/utils.py
+++ b/philharmonic/utils.py
@@ -22,17 +22,10 @@ def mkdir_p(path):
             pass
         else: raise
 
-# def loc(filepath):
-#     from philharmonic import conf
-#     if conf.add_date_to_folders:
-#         return loc_date(filepath)
-#     else:
-#         return loc_normal(filepath)
-
-def loc(filepath):
+def loc(filepath, input=False):
     from philharmonic import conf
     if conf.add_date_to_folders:
-        return loc_date(filepath)
+        return loc_date(filepath, input)
     else:
         return loc_normal(filepath)
 
@@ -42,14 +35,19 @@ def loc_normal(filepath):
     mkdir_p(new_path)
     return os.path.join(conf.output_folder, filepath)
 
-def loc_date(filepath):
+def loc_date(filepath, input):
     from philharmonic import conf
     from time import strftime
     from time import mktime
     date = strftime("%Y-%m-%d", conf.current_time)
     time = strftime("%H%M%S", conf.current_time)
     filepath = os.path.basename(filepath)
-    filepath = time + "_" + filepath # save the time as part of the name of the output file
+
+    if(input): 
+        type = "input"
+    else:
+        type = "output"
+    filepath = time + "_" + type + "_" + filepath # save the time as part of the name of the output file
     filepath = date + "/" + filepath # put the file inside a folder of the current date
     new_path = os.path.join(conf.output_folder, os.path.dirname(filepath))
     mkdir_p(new_path)


### PR DESCRIPTION
**New config**

The config option `add_date_to_folders` will create a date folder as a subfolder from the selected config (i.e. ga/2015-05-06). 

Inside the date folder the generated files will be saved prefixed with a timestamp (i.e. 114430 for 11:44:30) and an indicator whether the files are input or output (input = requests,servers; output = results,schedule)

Sample files would be 
- 114430_input_requests
- 114430_input_servers
- 114430_output_results
- 114430_output_schedule

Saved in folder ga/2015-05-06/ (or whatever the current date is). 

Now the inputs as well as the outputs are saved at a common place easily to be recognized by a unique timestamp. If you don't need this option, simply deactivate it by setting `add_date_to_folders = False` in your custom settings file. 
